### PR TITLE
Add the generation of Models, migrations and model factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The package will automatically detect your namespace from your `composer.json` a
 ./vendor/bin/pkg-tools make:migration name [--create=] [--force]
 
 ./vendor/bin/pkg-tools make:factory name [--model=] [--force]
+
+./vendor/bin/pkg-tools make:model name [--m|migration] [--f|factory] [--force]
 ``` 
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The package will automatically detect your namespace from your `composer.json` a
 ./vendor/bin/pkg-tools make:notification name [--force]
 
 ./vendor/bin/pkg-tools make:rule name [--force]
+
+./vendor/bin/pkg-tools make:migration name [--create=] [--force]
 ``` 
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The package will automatically detect your namespace from your `composer.json` a
 ./vendor/bin/pkg-tools make:rule name [--force]
 
 ./vendor/bin/pkg-tools make:migration name [--create=] [--force]
+
+./vendor/bin/pkg-tools make:factory name [--model=] [--force]
 ``` 
 
 ### Testing

--- a/pkg-tools
+++ b/pkg-tools
@@ -10,6 +10,7 @@ use BeyondCode\LaravelPackageTools\Commands\MakeJob;
 use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
 use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 use BeyondCode\LaravelPackageTools\Commands\MakeRule;
+use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
 
 $version = '1.0.0';
 
@@ -21,5 +22,6 @@ $app->command('make:job name [--sync] [--force]', new MakeJob);
 $app->command('make:event name [--force]', new MakeEvent);
 $app->command('make:notification name [--force]', new MakeNotification);
 $app->command('make:rule name [--force]', new MakeRule);
+$app->command('make:migration name [--create=] [--force]', new MakeMigration);
 
 $app->run();

--- a/pkg-tools
+++ b/pkg-tools
@@ -11,6 +11,7 @@ use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
 use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
+use BeyondCode\LaravelPackageTools\Commands\MakeFactory;
 
 $version = '1.0.0';
 
@@ -23,5 +24,6 @@ $app->command('make:event name [--force]', new MakeEvent);
 $app->command('make:notification name [--force]', new MakeNotification);
 $app->command('make:rule name [--force]', new MakeRule);
 $app->command('make:migration name [--create=] [--force]', new MakeMigration);
+$app->command('make:factory name [--model=] [--force]', new MakeFactory);
 
 $app->run();

--- a/pkg-tools
+++ b/pkg-tools
@@ -12,6 +12,7 @@ use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
 use BeyondCode\LaravelPackageTools\Commands\MakeFactory;
+use BeyondCode\LaravelPackageTools\Commands\MakeModel;
 
 $version = '1.0.0';
 
@@ -25,5 +26,6 @@ $app->command('make:notification name [--force]', new MakeNotification);
 $app->command('make:rule name [--force]', new MakeRule);
 $app->command('make:migration name [--create=] [--force]', new MakeMigration);
 $app->command('make:factory name [--model=] [--force]', new MakeFactory);
+$app->command('make:model name [--m|migration] [--f|factory] [--force]', new MakeModel);
 
 $app->run();

--- a/src/Commands/MakeFactory.php
+++ b/src/Commands/MakeFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BeyondCode\LaravelPackageTools\Commands;
+
+class MakeFactory extends GeneratorCommand
+{
+    protected $type = 'Factory';
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/factory.stub';
+    }
+
+    protected function qualifyClass($name)
+    {
+        return $this->rootNamespace() . '\\..\\database\\factories\\' . $name;
+    }
+
+    protected function replaceNamespace(&$stub, $name)
+    {
+        $stub = str_replace(
+            ['DummyNamespace', 'DummyRootNamespace\\'],
+            ['Models\\' . $this->option('model', 'Factory'), $this->rootNamespace()],
+            $stub
+        );
+
+        return $this;
+    }
+
+    protected function replaceClass($stub, $name)
+    {
+        return str_replace('Dummy::class', $this->option('model', 'Factory') . '::class', $stub);
+    }
+}

--- a/src/Commands/MakeFactory.php
+++ b/src/Commands/MakeFactory.php
@@ -13,14 +13,14 @@ class MakeFactory extends GeneratorCommand
 
     protected function qualifyClass($name)
     {
-        return $this->rootNamespace() . '\\..\\database\\factories\\' . $name;
+        return $this->rootNamespace().'\\..\\database\\factories\\'.$name;
     }
 
     protected function replaceNamespace(&$stub, $name)
     {
         $stub = str_replace(
             ['DummyNamespace', 'DummyRootNamespace\\'],
-            ['Models\\' . $this->option('model', 'Factory'), $this->rootNamespace()],
+            ['Models\\'.$this->option('model', 'Factory'), $this->rootNamespace()],
             $stub
         );
 
@@ -29,6 +29,6 @@ class MakeFactory extends GeneratorCommand
 
     protected function replaceClass($stub, $name)
     {
-        return str_replace('Dummy::class', $this->option('model', 'Factory') . '::class', $stub);
+        return str_replace('Dummy::class', $this->option('model', 'Factory').'::class', $stub);
     }
 }

--- a/src/Commands/MakeMigration.php
+++ b/src/Commands/MakeMigration.php
@@ -15,7 +15,7 @@ class MakeMigration extends GeneratorCommand
 
     protected function qualifyClass($name)
     {
-        return $this->rootNamespace() . '\\..\\database\\migrations\\' . $name;
+        return $this->rootNamespace().'\\..\\database\\migrations\\'.$name;
     }
 
     protected function replaceClass($stub, $name)
@@ -28,6 +28,7 @@ class MakeMigration extends GeneratorCommand
     protected function getClassName($stub, $name)
     {
         $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
         return ucfirst(Str::camel($class));
     }
 }

--- a/src/Commands/MakeMigration.php
+++ b/src/Commands/MakeMigration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BeyondCode\LaravelPackageTools\Commands;
+
+use Illuminate\Support\Str;
+
+class MakeMigration extends GeneratorCommand
+{
+    protected $type = 'Migration';
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/migration.stub';
+    }
+
+    protected function qualifyClass($name)
+    {
+        return $this->rootNamespace() . '\\..\\database\\migrations\\' . $name;
+    }
+
+    protected function replaceClass($stub, $name)
+    {
+        $stub = str_replace('CreateDummiesTable', $this->getClassName($stub, $name), $stub);
+
+        return str_replace('dummies', $this->option('create', 'table_name'), $stub);
+    }
+
+    protected function getClassName($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+        return ucfirst(Str::camel($class));
+    }
+}

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -4,10 +4,10 @@ namespace BeyondCode\LaravelPackageTools\Commands;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,11 +19,11 @@ class MakeModel extends GeneratorCommand
     {
         parent::__invoke($input, $output);
 
-        if($this->input->getOption('migration')) {
+        if ($this->input->getOption('migration')) {
             $this->createMigration();
         }
 
-        if($this->input->getOption('factory')) {
+        if ($this->input->getOption('factory')) {
             $this->createFactory();
         }
     }
@@ -44,7 +44,7 @@ class MakeModel extends GeneratorCommand
 
         $this->runCommand("create_{$table}_table", ['--create' => "{$table}"], new MakeMigration);
 
-        $this->info(PHP_EOL . "Created migration: create_{$table}_table");
+        $this->info(PHP_EOL."Created migration: create_{$table}_table");
     }
 
     protected function createFactory()
@@ -53,21 +53,23 @@ class MakeModel extends GeneratorCommand
 
         $this->runCommand("{$model}Factory", ['--model' => "{$model}"], new MakeFactory);
 
-        $this->info(PHP_EOL . "Factory created successfully.");
+        $this->info(PHP_EOL.'Factory created successfully.');
     }
 
     protected function runCommand($name, $options, GeneratorCommand $command)
     {
-        $input = new ArrayInput(array_merge([
+        $input = new ArrayInput(
+            array_merge([
             'name'  => $name,
             '--force' => false,
-        ], $options),
+            ], $options),
             new InputDefinition([
                 new InputArgument('name'),
                 new InputOption('create'),
                 new InputOption('model'),
                 new InputOption('force'),
-        ]));
+            ])
+        );
 
         $output = new BufferedOutput();
 

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace BeyondCode\LaravelPackageTools\Commands;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MakeModel extends GeneratorCommand
+{
+    protected $type = 'Model';
+
+    public function __invoke(InputInterface $input, OutputInterface $output)
+    {
+        parent::__invoke($input, $output);
+
+        if($this->input->getOption('migration')) {
+            $this->createMigration();
+        }
+
+        if($this->input->getOption('factory')) {
+            $this->createFactory();
+        }
+    }
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/model.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Models';
+    }
+
+    private function createMigration()
+    {
+        $table = Str::snake(Str::pluralStudly(class_basename($this->getNameInput())));
+
+        $this->runCommand("create_{$table}_table", ['--create' => "{$table}"], new MakeMigration);
+
+        $this->info(PHP_EOL . "Created migration: create_{$table}_table");
+    }
+
+    protected function createFactory()
+    {
+        $model = $this->getNameInput();
+
+        $this->runCommand("{$model}Factory", ['--model' => "{$model}"], new MakeFactory);
+
+        $this->info(PHP_EOL . "Factory created successfully.");
+    }
+
+    protected function runCommand($name, $options, GeneratorCommand $command)
+    {
+        $input = new ArrayInput(array_merge([
+            'name'  => $name,
+            '--force' => false,
+        ], $options),
+            new InputDefinition([
+                new InputArgument('name'),
+                new InputOption('create'),
+                new InputOption('model'),
+                new InputOption('force'),
+        ]));
+
+        $output = new BufferedOutput();
+
+        $command->outputPath = ($this->outputPath);
+
+        $command->__invoke($input, $output);
+    }
+}

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -40,7 +40,7 @@ class MakeModel extends GeneratorCommand
 
     private function createMigration()
     {
-        $table = Str::snake(Str::pluralStudly(class_basename($this->getNameInput())));
+        $table = Str::snake(Str::plural(class_basename($this->getNameInput())));
 
         $this->runCommand("create_{$table}_table", ['--create' => "{$table}"], new MakeMigration);
 

--- a/src/Commands/stubs/factory.stub
+++ b/src/Commands/stubs/factory.stub
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use DummyRootNamespace\DummyNamespace;
+use Faker\Generator as Faker;
+
+$factory->define(Dummy::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/src/Commands/stubs/migration.stub
+++ b/src/Commands/stubs/migration.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDummiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('dummies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('dummies');
+    }
+}

--- a/src/Commands/stubs/model.stub
+++ b/src/Commands/stubs/model.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model
+{
+    //
+}

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -14,8 +14,8 @@ use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
 use BeyondCode\LaravelPackageTools\Commands\MakeModel;
 use BeyondCode\LaravelPackageTools\Commands\MakeCommand;
-use BeyondCode\LaravelPackageTools\Commands\MakeRequest;
 use BeyondCode\LaravelPackageTools\Commands\MakeFactory;
+use BeyondCode\LaravelPackageTools\Commands\MakeRequest;
 use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
 use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 
@@ -25,7 +25,7 @@ class GenerationTest extends TestCase
 
     protected $outputPath;
 
-    function setUp(): void
+    public function setUp(): void
     {
         parent::setUp();
         $this->outputPath = __DIR__.'/output/src/';
@@ -181,7 +181,7 @@ class GenerationTest extends TestCase
     }
 
     /** @test */
-    function it_can_make_model_factory_classes()
+    public function it_can_make_model_factory_classes()
     {
         $input = new ArrayInput([
             'name' => 'ExampleFactory',
@@ -235,7 +235,7 @@ class GenerationTest extends TestCase
     }
 
     /** @test */
-    function it_can_make_model_classes_without_factories_and_migrations()
+    public function it_can_make_model_classes_without_factories_and_migrations()
     {
         $input = new ArrayInput([
             'name' => 'SingleModel',

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -14,6 +14,7 @@ use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
 use BeyondCode\LaravelPackageTools\Commands\MakeCommand;
 use BeyondCode\LaravelPackageTools\Commands\MakeRequest;
+use BeyondCode\LaravelPackageTools\Commands\MakeFactory;
 use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
 use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 
@@ -176,5 +177,28 @@ class GenerationTest extends TestCase
 
         $this->assertTrue(file_exists($command->outputPath.'../database/migrations/create_example_migrations_table.php'));
         $this->assertMatchesFileSnapshot($command->outputPath.'../database/migrations/create_example_migrations_table.php');
+    }
+
+    /** @test */
+    function it_can_make_model_factory_classes()
+    {
+        $input = new ArrayInput([
+            'name' => 'ExampleFactory',
+            '--model' => 'ExampleFactoryModel',
+            '--force' => true,
+        ], new InputDefinition([
+            new InputArgument('name'),
+            new InputOption('force'),
+            new InputOption('model'),
+        ]));
+
+        $output = new BufferedOutput();
+
+        $command = new MakeFactory;
+        $command->outputPath = $this->outputPath;
+        $command->__invoke($input, $output);
+
+        $this->assertTrue(file_exists($command->outputPath.'../database/factories/ExampleFactory.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'../database/factories/ExampleFactory.php');
     }
 }

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -14,6 +14,7 @@ use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
 use BeyondCode\LaravelPackageTools\Commands\MakeCommand;
 use BeyondCode\LaravelPackageTools\Commands\MakeRequest;
+use BeyondCode\LaravelPackageTools\Commands\MakeMigration;
 use BeyondCode\LaravelPackageTools\Commands\MakeNotification;
 
 class GenerationTest extends TestCase
@@ -152,5 +153,28 @@ class GenerationTest extends TestCase
 
         $this->assertTrue(file_exists($command->outputPath.'/Notifications/ExampleNotification.php'));
         $this->assertMatchesFileSnapshot($command->outputPath.'/Notifications/ExampleNotification.php');
+    }
+
+    /** @test */
+    public function it_can_make_migration_classes()
+    {
+        $input = new ArrayInput([
+            'name' => 'create_example_migrations_table',
+            '--create' => 'example_migrations',
+            '--force' => true,
+        ], new InputDefinition([
+            new InputArgument('name'),
+            new InputOption('force'),
+            new InputOption('create'),
+        ]));
+
+        $output = new BufferedOutput();
+
+        $command = new MakeMigration;
+        $command->outputPath = $this->outputPath;
+        $command->__invoke($input, $output);
+
+        $this->assertTrue(file_exists($command->outputPath.'../database/migrations/create_example_migrations_table.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'../database/migrations/create_example_migrations_table.php');
     }
 }

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\BufferedOutput;
 use BeyondCode\LaravelPackageTools\Commands\MakeRule;
 use BeyondCode\LaravelPackageTools\Commands\MakeEvent;
+use BeyondCode\LaravelPackageTools\Commands\MakeModel;
 use BeyondCode\LaravelPackageTools\Commands\MakeCommand;
 use BeyondCode\LaravelPackageTools\Commands\MakeRequest;
 use BeyondCode\LaravelPackageTools\Commands\MakeFactory;
@@ -200,5 +201,64 @@ class GenerationTest extends TestCase
 
         $this->assertTrue(file_exists($command->outputPath.'../database/factories/ExampleFactory.php'));
         $this->assertMatchesFileSnapshot($command->outputPath.'../database/factories/ExampleFactory.php');
+    }
+
+    /** @test */
+    public function it_can_make_model_classes_with_migrations_and_factories()
+    {
+        $input = new ArrayInput([
+            'name' => 'ExampleModel',
+            '--migration' => true,
+            '--factory' => true,
+            '--force' => true,
+        ], new InputDefinition([
+            new InputArgument('name'),
+            new InputOption('force'),
+            new InputOption('migration'),
+            new InputOption('factory'),
+        ]));
+
+        $output = new BufferedOutput();
+
+        $command = new MakeModel();
+        $command->outputPath = $this->outputPath;
+        $command->__invoke($input, $output);
+
+        $this->assertTrue(file_exists($command->outputPath.'/Models/ExampleModel.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'/Models/ExampleModel.php');
+
+        $this->assertTrue(file_exists($command->outputPath.'../database/migrations/create_example_models_table.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'../database/migrations/create_example_models_table.php');
+
+        $this->assertTrue(file_exists($command->outputPath.'../database/factories/ExampleModelFactory.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'../database/factories/ExampleModelFactory.php');
+    }
+
+    /** @test */
+    function it_can_make_model_classes_without_factories_and_migrations()
+    {
+        $input = new ArrayInput([
+            'name' => 'SingleModel',
+            '--migration' => false,
+            '--factory' => false,
+            '--force' => true,
+        ], new InputDefinition([
+            new InputArgument('name'),
+            new InputOption('force'),
+            new InputOption('migration'),
+            new InputOption('factory'),
+        ]));
+
+        $output = new BufferedOutput();
+
+        $command = new MakeModel();
+        $command->outputPath = $this->outputPath;
+        $command->__invoke($input, $output);
+
+        $this->assertTrue(file_exists($command->outputPath.'/Models/SingleModel.php'));
+        $this->assertMatchesFileSnapshot($command->outputPath.'/Models/SingleModel.php');
+
+        $this->assertFalse(file_exists($command->outputPath.'../database/migrations/create_single_models_table.php'));
+        $this->assertFalse(file_exists($command->outputPath.'../database/factories/SingleModelFactory.php'));
     }
 }

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -20,6 +20,14 @@ class GenerationTest extends TestCase
 {
     use MatchesSnapshots;
 
+    protected $outputPath;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->outputPath = __DIR__.'/output/src/';
+    }
+
     /** @test */
     public function it_can_make_rule_classes()
     {
@@ -34,7 +42,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeRule;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Rules/ExampleRule.php'));
@@ -55,7 +63,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeCommand;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Console/Commands/ExampleCommand.php'));
@@ -76,7 +84,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeRequest;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Http/Requests/ExampleRequest.php'));
@@ -97,7 +105,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeJob;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Jobs/ExampleJob.php'));
@@ -118,7 +126,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeEvent;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Events/ExampleEvent.php'));
@@ -139,7 +147,7 @@ class GenerationTest extends TestCase
         $output = new BufferedOutput();
 
         $command = new MakeNotification;
-        $command->outputPath = __DIR__.'/output/';
+        $command->outputPath = $this->outputPath;
         $command->__invoke($input, $output);
 
         $this->assertTrue(file_exists($command->outputPath.'/Notifications/ExampleNotification.php'));

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_migration_classes__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_migration_classes__1.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateExampleMigrationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('example_migrations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('example_migrations');
+    }
+}

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_migration_classes__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_migration_classes__1.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreateExampleMigrationsTable extends Migration
 {

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__1.php
@@ -4,7 +4,7 @@ namespace BeyondCode\LaravelPackageTools\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class ExampleModel extends Model
+class ExampleTest__it_can_make_model_classes_with_migrations_and_factories__1 extends Model
 {
     //
 }

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BeyondCode\LaravelPackageTools\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ExampleModel extends Model
+{
+    //
+}

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__2.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__2.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class CreateExampleModelsTable extends Migration
 {

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__2.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__2.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateExampleModelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('example_models', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('example_models');
+    }
+}

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__3.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__3.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use BeyondCode\LaravelPackageTools\Models\ExampleModel;
+use Faker\Generator as Faker;
+
+$factory->define(ExampleModel::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__3.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_with_migrations_and_factories__3.php
@@ -1,9 +1,8 @@
 <?php
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
-
-use BeyondCode\LaravelPackageTools\Models\ExampleModel;
 use Faker\Generator as Faker;
+use BeyondCode\LaravelPackageTools\Models\ExampleModel;
 
 $factory->define(ExampleModel::class, function (Faker $faker) {
     return [

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_without_factories_and_migrations__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_without_factories_and_migrations__1.php
@@ -4,7 +4,7 @@ namespace BeyondCode\LaravelPackageTools\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class SingleModel extends Model
+class ExampleTest__it_can_make_model_classes_without_factories_and_migrations__1 extends Model
 {
     //
 }

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_without_factories_and_migrations__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_classes_without_factories_and_migrations__1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BeyondCode\LaravelPackageTools\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SingleModel extends Model
+{
+    //
+}

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_factory_classes__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_factory_classes__1.php
@@ -1,9 +1,8 @@
 <?php
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
-
-use BeyondCode\LaravelPackageTools\Models\ExampleFactoryModel;
 use Faker\Generator as Faker;
+use BeyondCode\LaravelPackageTools\Models\ExampleFactoryModel;
 
 $factory->define(ExampleFactoryModel::class, function (Faker $faker) {
     return [

--- a/tests/__snapshots__/files/ExampleTest__it_can_make_model_factory_classes__1.php
+++ b/tests/__snapshots__/files/ExampleTest__it_can_make_model_factory_classes__1.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use BeyondCode\LaravelPackageTools\Models\ExampleFactoryModel;
+use Faker\Generator as Faker;
+
+$factory->define(ExampleFactoryModel::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});


### PR DESCRIPTION
In this PR I've added the ability to generate model classes, migration classes and model factory classes. The models can be generated with or without accompanying migrations and/or model factories. 

The classes can be generated as described in the updated readme. 

To create a migration and a factory together with a model, users can attach the `-m` or `-f` flags (like in a Laravel application) or use the fully specified flags `--migration` or `--factory`.

`./vendor/bin/pkg-tools make:model ExampleModel -mf`

Let me know if there are some things up for improvement.