### PR TITLE
Add support for Laravel 6.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|6.0.*",
         "mnapoli/silly": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
I wanted to add support for Laravel 6.0, and added the following to composer.json. I don't know if I should add anything else to allow for Laravel 6.0?